### PR TITLE
Add activity response for a logged in user

### DIFF
--- a/backend/db/store.go
+++ b/backend/db/store.go
@@ -295,6 +295,7 @@ func (s *Store) GetActivityFeed(userID int64, pageNumber int64) ([]types.UserPos
 		P.user_post_id,
 		P.is_public,
 		P.concert_id,
+		A.name AS artist_name,
 		C.date AS concert_date,
 		T.name AS tour_name,
 		V.name AS venue_name,
@@ -309,6 +310,7 @@ func (s *Store) GetActivityFeed(userID int64, pageNumber int64) ([]types.UserPos
 		JOIN concerts C ON P.concert_id = C.id
 		JOIN tours T ON C.tour_id = T.id
 		JOIN venues V ON C.venue_id = V.id
+		JOIN artists A ON C.artist_id = A.id
 		WHERE U.id = ?
 		AND P.is_public = 1
 		ORDER BY P.updated_at DESC

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -556,8 +556,11 @@ const docTemplate = `{
         "types.UserPostGetResponse": {
             "type": "object",
             "properties": {
-                "authorID": {
-                    "type": "integer"
+                "authorName": {
+                    "type": "string"
+                },
+                "concertDate": {
+                    "type": "string"
                 },
                 "concertID": {
                     "type": "integer"
@@ -565,16 +568,19 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
-                "id": {
-                    "type": "integer"
-                },
                 "isPublic": {
                     "type": "boolean"
+                },
+                "postID": {
+                    "type": "integer"
                 },
                 "rating": {
                     "type": "integer"
                 },
                 "text": {
+                    "type": "string"
+                },
+                "tourName": {
                     "type": "string"
                 },
                 "type": {
@@ -585,6 +591,15 @@ const docTemplate = `{
                 },
                 "userPostID": {
                     "type": "integer"
+                },
+                "venueCity": {
+                    "type": "string"
+                },
+                "venueCountry": {
+                    "type": "string"
+                },
+                "venueName": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -339,6 +339,51 @@ const docTemplate = `{
             }
         },
         "/userpost": {
+            "get": {
+                "description": "Gets public posts from a user's followed network, sorted with most recent first",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get posts for user dashboard",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of logged in user",
+                        "name": "userID",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page number of posts (sets of 20)",
+                        "name": "p",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Activity from user's followed network",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserPostGetResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Error describing failure",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates a post for a user. Can be set to public or private with IsPublic",
                 "consumes": [
@@ -502,6 +547,41 @@ const docTemplate = `{
                         "REVIEW",
                         "LISTCREATED"
                     ]
+                },
+                "userPostID": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UserPostGetResponse": {
+            "type": "object",
+            "properties": {
+                "authorID": {
+                    "type": "integer"
+                },
+                "concertID": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublic": {
+                    "type": "boolean"
+                },
+                "rating": {
+                    "type": "integer"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 },
                 "userPostID": {
                     "type": "integer"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -336,6 +336,51 @@
             }
         },
         "/userpost": {
+            "get": {
+                "description": "Gets public posts from a user's followed network, sorted with most recent first",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get posts for user dashboard",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of logged in user",
+                        "name": "userID",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page number of posts (sets of 20)",
+                        "name": "p",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Activity from user's followed network",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserPostGetResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Error describing failure",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates a post for a user. Can be set to public or private with IsPublic",
                 "consumes": [
@@ -499,6 +544,41 @@
                         "REVIEW",
                         "LISTCREATED"
                     ]
+                },
+                "userPostID": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UserPostGetResponse": {
+            "type": "object",
+            "properties": {
+                "authorID": {
+                    "type": "integer"
+                },
+                "concertID": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublic": {
+                    "type": "boolean"
+                },
+                "rating": {
+                    "type": "integer"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 },
                 "userPostID": {
                     "type": "integer"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -553,8 +553,11 @@
         "types.UserPostGetResponse": {
             "type": "object",
             "properties": {
-                "authorID": {
-                    "type": "integer"
+                "authorName": {
+                    "type": "string"
+                },
+                "concertDate": {
+                    "type": "string"
                 },
                 "concertID": {
                     "type": "integer"
@@ -562,16 +565,19 @@
                 "createdAt": {
                     "type": "string"
                 },
-                "id": {
-                    "type": "integer"
-                },
                 "isPublic": {
                     "type": "boolean"
+                },
+                "postID": {
+                    "type": "integer"
                 },
                 "rating": {
                     "type": "integer"
                 },
                 "text": {
+                    "type": "string"
+                },
+                "tourName": {
                     "type": "string"
                 },
                 "type": {
@@ -582,6 +588,15 @@
                 },
                 "userPostID": {
                     "type": "integer"
+                },
+                "venueCity": {
+                    "type": "string"
+                },
+                "venueCountry": {
+                    "type": "string"
+                },
+                "venueName": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -67,19 +67,23 @@ definitions:
     type: object
   types.UserPostGetResponse:
     properties:
-      authorID:
-        type: integer
+      authorName:
+        type: string
+      concertDate:
+        type: string
       concertID:
         type: integer
       createdAt:
         type: string
-      id:
-        type: integer
       isPublic:
         type: boolean
+      postID:
+        type: integer
       rating:
         type: integer
       text:
+        type: string
+      tourName:
         type: string
       type:
         type: string
@@ -87,6 +91,12 @@ definitions:
         type: string
       userPostID:
         type: integer
+      venueCity:
+        type: string
+      venueCountry:
+        type: string
+      venueName:
+        type: string
     type: object
   types.UserRegisterPayload:
     properties:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -65,6 +65,29 @@ definitions:
     - isPublic
     - type
     type: object
+  types.UserPostGetResponse:
+    properties:
+      authorID:
+        type: integer
+      concertID:
+        type: integer
+      createdAt:
+        type: string
+      id:
+        type: integer
+      isPublic:
+        type: boolean
+      rating:
+        type: integer
+      text:
+        type: string
+      type:
+        type: string
+      updatedAt:
+        type: string
+      userPostID:
+        type: integer
+    type: object
   types.UserRegisterPayload:
     properties:
       email:
@@ -302,6 +325,37 @@ paths:
       tags:
       - Auth
   /userpost:
+    get:
+      description: Gets public posts from a user's followed network, sorted with most
+        recent first
+      parameters:
+      - description: ID of logged in user
+        in: query
+        name: userID
+        required: true
+        type: string
+      - description: page number of posts (sets of 20)
+        in: query
+        name: p
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Activity from user's followed network
+          schema:
+            $ref: '#/definitions/types.UserPostGetResponse'
+        "400":
+          description: Error describing failure
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Get posts for user dashboard
+      tags:
+      - User
     post:
       consumes:
       - application/json

--- a/backend/routes/methods_user.go
+++ b/backend/routes/methods_user.go
@@ -81,7 +81,7 @@ func (h *Handler) UserPostOnGet(w http.ResponseWriter, r *http.Request) {
 
 	userID, err := strconv.ParseInt(userIDString, 10, 64)
 	if err != nil {
-		utils.WriteError(w, http.StatusBadRequest, fmt.Errorf("bad UserPostID provided %v", userIDString))
+		utils.WriteError(w, http.StatusBadRequest, fmt.Errorf("bad userID provided %v", userIDString))
 		return
 	}
 

--- a/backend/routes/methods_user.go
+++ b/backend/routes/methods_user.go
@@ -12,6 +12,16 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+// @Summary Create user post
+// @Description Creates a post for a user. Can be set to public or private with IsPublic
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param request body types.UserPostCreatePayload true "User Post Creation Payload"
+// @Success 201 {string} string "Post created successfully"
+// @Failure 400 {string} string "Error describing failure - including duplicate attendance posts"
+// @Failure 500 {string} string "Internal server error"
+// @Router /userpost [post]
 func (h *Handler) UserPostOnPost(w http.ResponseWriter, r *http.Request) {
 	var payload types.UserPostCreatePayload
 	if err := utils.ParseJSON(r, &payload); err != nil {
@@ -51,6 +61,22 @@ func (h *Handler) UserPostOnPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteJSON(w, http.StatusCreated, nil)
+}
+
+// @Summary Get posts for user dashboard
+// @Description Gets public posts from a user's followed network, sorted with most recent first
+// @Tags User
+// @Produce json
+// @Success 200 {object} TODO "Activity from user's followed network"
+// @Failure 400 {string} string "Error describing failure"
+// @Failure 500 {string} string "Internal server error"
+// @Router /userpost [get]
+func (h *Handler) UserPostOnGet(w http.ResponseWriter, r *http.Request) {
+	userPostIDString := r.URL.Query().Get("userID")
+	if userPostIDString == "" {
+		utils.WriteError(w, http.StatusBadRequest, errors.New("userID not provided"))
+		return
+	}
 }
 
 // @Summary Like or unlike a post

--- a/backend/routes/methods_user.go
+++ b/backend/routes/methods_user.go
@@ -60,16 +60,38 @@ func (h *Handler) UserPostOnPost(w http.ResponseWriter, r *http.Request) {
 // @Description Gets public posts from a user's followed network, sorted with most recent first
 // @Tags User
 // @Produce json
-// @Success 200 {object} TODO "Activity from user's followed network"
+// @Param userID query string true "ID of logged in user"
+// @Param p query string false "page number of posts (sets of 20)"
+// @Success 200 {object} types.UserPostGetResponse "Activity from user's followed network"
 // @Failure 400 {string} string "Error describing failure"
 // @Failure 500 {string} string "Internal server error"
 // @Router /userpost [get]
 func (h *Handler) UserPostOnGet(w http.ResponseWriter, r *http.Request) {
-	userPostIDString := r.URL.Query().Get("userID")
-	if userPostIDString == "" {
+	userIDString := r.URL.Query().Get("userID")
+	if userIDString == "" {
 		utils.WriteError(w, http.StatusBadRequest, errors.New("userID not provided"))
 		return
 	}
+
+	pageNumberString := r.URL.Query().Get("p")
+	pageNumber, err := strconv.ParseInt(pageNumberString, 10, 64)
+	if err != nil {
+		pageNumber = 0
+	}
+
+	userID, err := strconv.ParseInt(userIDString, 10, 64)
+	if err != nil {
+		utils.WriteError(w, http.StatusBadRequest, fmt.Errorf("bad UserPostID provided %v", userIDString))
+		return
+	}
+
+	posts, err := h.Store.GetActivityFeed(userID, pageNumber)
+	if err != nil {
+		utils.WriteError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	utils.WriteJSON(w, http.StatusOK, posts)
 }
 
 // @Summary Like or unlike a post

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -38,7 +38,7 @@ func (h *Handler) RegisterRoutes(router *mux.Router) {
 	router.HandleFunc("/artist", h.handleArtist(baseURL)).Methods("GET", "OPTIONS")
 	router.HandleFunc("/import", h.handleArtistImport(baseURL)).Methods("GET", "OPTIONS")
 	router.HandleFunc("/concert", h.handleConcert(baseURL)).Methods("GET", "OPTIONS")
-	router.HandleFunc("/userpost", h.handleUserPost()).Methods("POST", "OPTIONS")
+	router.HandleFunc("/userpost", h.handleUserPost()).Methods("GET", "POST", "OPTIONS")
 	router.HandleFunc("/like", h.handleUserLike()).Methods("GET", "POST", "OPTIONS")
 	router.HandleFunc("/follow", h.handleUserFollow()).Methods("POST", "OPTIONS")
 

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -584,16 +584,6 @@ func (h *Handler) handleConcert(inputURL string) http.HandlerFunc {
 	}
 }
 
-// @Summary Create user post
-// @Description Creates a post for a user. Can be set to public or private with IsPublic
-// @Tags User
-// @Accept json
-// @Produce json
-// @Param request body types.UserPostCreatePayload true "User Post Creation Payload"
-// @Success 201 {string} string "Post created successfully"
-// @Failure 400 {string} string "Error describing failure - including duplicate attendance posts"
-// @Failure 500 {string} string "Internal server error"
-// @Router /userpost [post]
 func (h *Handler) handleUserPost() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		utils.SetCORSHeaders(w)
@@ -604,6 +594,10 @@ func (h *Handler) handleUserPost() http.HandlerFunc {
 
 		if r.Method == http.MethodPost {
 			h.UserPostOnPost(w, r)
+		}
+
+		if r.Method == http.MethodGet {
+			h.UserPostOnGet(w, r)
 		}
 	}
 }

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -789,6 +789,54 @@ func TestUserServiceHandlePost(t *testing.T) {
 
 		assertEqual(t, http.StatusCreated, rr.Code)
 	})
+
+	t.Run("GET should fail with no userID query parameter", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/userpost", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+
+		router.HandleFunc("/userpost", handler.handleUserPost())
+
+		router.ServeHTTP(rr, req)
+
+		assertEqual(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("GET should fail with bad userID query parameter", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/userpost?userID=test", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+
+		router.HandleFunc("/userpost", handler.handleUserPost())
+
+		router.ServeHTTP(rr, req)
+
+		assertEqual(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("GET should pass with valid userID query parameter", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/userpost?userID=1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+
+		router.HandleFunc("/userpost", handler.handleUserPost())
+
+		router.ServeHTTP(rr, req)
+
+		assertEqual(t, http.StatusOK, rr.Code)
+	})
 }
 
 func TestUserServiceHandleLike(t *testing.T) {

--- a/backend/types/concerto_store_interface.go
+++ b/backend/types/concerto_store_interface.go
@@ -22,4 +22,5 @@ type Store interface {
 	ToggleUserFollow(UserFollowPayload) error
 	UserPostExists(authorID, concertID uint, postType string) (bool, error)
 	GetNumberOfLikes(int64) (int64, error)
+	GetActivityFeed(int64, int64) ([]UserPostGetResponse, error)
 }

--- a/backend/types/concerto_userpost_types.go
+++ b/backend/types/concerto_userpost_types.go
@@ -30,6 +30,7 @@ type UserPostGetResponse struct {
 	UserPostID   *uint     `json:"userPostID"`
 	IsPublic     bool      `json:"isPublic"`
 	ConcertID    uint      `json:"concertID"`
+	ArtistName   string    `json:"artistName"`
 	ConcertDate  time.Time `json:"concertDate"`
 	TourName     string    `json:"tourName"`
 	VenueName    string    `json:"venueName"`

--- a/backend/types/concerto_userpost_types.go
+++ b/backend/types/concerto_userpost_types.go
@@ -21,6 +21,19 @@ type UserLikeGetResponse struct {
 	Count int64 `json:"count"`
 }
 
+type UserPostGetResponse struct {
+	ID         uint      `json:"id"`
+	AuthorID   uint      `json:"authorID"`
+	Text       *string   `json:"text"`
+	Type       string    `json:"type"`
+	Rating     *uint     `json:"rating"`
+	UserPostID *uint     `json:"userPostID"`
+	IsPublic   bool      `json:"isPublic"`
+	ConcertID  uint      `json:"concertID"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
 type UserPost struct {
 	ID         uint    `gorm:"primaryKey"`
 	AuthorID   uint    `gorm:"index"`

--- a/backend/types/concerto_userpost_types.go
+++ b/backend/types/concerto_userpost_types.go
@@ -22,16 +22,21 @@ type UserLikeGetResponse struct {
 }
 
 type UserPostGetResponse struct {
-	ID         uint      `json:"id"`
-	AuthorID   uint      `json:"authorID"`
-	Text       *string   `json:"text"`
-	Type       string    `json:"type"`
-	Rating     *uint     `json:"rating"`
-	UserPostID *uint     `json:"userPostID"`
-	IsPublic   bool      `json:"isPublic"`
-	ConcertID  uint      `json:"concertID"`
-	CreatedAt  time.Time `json:"createdAt"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	PostID       uint      `json:"postID"`
+	AuthorName   string    `json:"authorName"`
+	Text         *string   `json:"text"`
+	Type         string    `json:"type"`
+	Rating       *uint     `json:"rating"`
+	UserPostID   *uint     `json:"userPostID"`
+	IsPublic     bool      `json:"isPublic"`
+	ConcertID    uint      `json:"concertID"`
+	ConcertDate  time.Time `json:"concertDate"`
+	TourName     string    `json:"tourName"`
+	VenueName    string    `json:"venueName"`
+	VenueCity    string    `json:"venueCity"`
+	VenueCountry string    `json:"venueCountry"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
 }
 
 type UserPost struct {


### PR DESCRIPTION
Serve all posts that a given logged in user's network has created.

Will return 20 posts at a time, all from users that the logged in user follows. Only public posts are shown. Sorted so most recent post is shown at the top.